### PR TITLE
[FEAT] : you can only add favorites when you are connected + link to …

### DIFF
--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -80,12 +80,19 @@ export default function Header() {
       </ul>
 
       <ul className={styles.ulUser}>
-        <NavLink className={styles.navLink} to="/">
-          <li>
-            <span className="material-symbols-outlined">favorite</span>
-            <p>Favoris</p>
-          </li>
-        </NavLink>
+        {isAuth ? (
+          <NavLink
+            className={styles.navLink}
+            to={`/user/${userName}/favorites`}
+          >
+            <li>
+              <span className="material-symbols-outlined">favorite</span>
+              <p>Favoris</p>
+            </li>
+          </NavLink>
+        ) : (
+          ""
+        )}
         <NavLink className={`${styles.navLink} ${styles.order}`} to="/panier">
           <li>
             <span className="material-symbols-outlined">shopping_cart</span>

--- a/client/src/components/ShopPage/ArticlePage/ArticleDetails.tsx
+++ b/client/src/components/ShopPage/ArticlePage/ArticleDetails.tsx
@@ -23,6 +23,7 @@ export default function ArticleDetails({
   const [showFullDescription, setShowFullDescription] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
   const [addToOrder, setAddToOrder] = useState(0);
+  const isAuth = localStorage.getItem("isAuth") === "true";
 
   useEffect(() => {
     const favorites = JSON.parse(localStorage.getItem("favorites") || "[]");
@@ -46,16 +47,20 @@ export default function ArticleDetails({
   }, []);
 
   const handleFavoriteClick = () => {
-    const favorites = JSON.parse(localStorage.getItem("favorites") || "[]");
-    let updatedFavorites: number[];
-
-    if (!isFavorite) {
-      updatedFavorites = [...favorites, id];
+    if (isAuth === false) {
+      alert("Merci de vous connecter pour ajouter des favoris");
     } else {
-      updatedFavorites = favorites.filter((fav: number) => fav !== id);
+      const favorites = JSON.parse(localStorage.getItem("favorites") || "[]");
+      let updatedFavorites: number[];
+
+      if (!isFavorite) {
+        updatedFavorites = [...favorites, id];
+      } else {
+        updatedFavorites = favorites.filter((fav: number) => fav !== id);
+      }
+      localStorage.setItem("favorites", JSON.stringify(updatedFavorites));
+      setIsFavorite(!isFavorite);
     }
-    localStorage.setItem("favorites", JSON.stringify(updatedFavorites));
-    setIsFavorite(!isFavorite);
   };
 
   const handleAddToOrder = () => {

--- a/client/src/components/UserAccount/AccountFavorite.tsx
+++ b/client/src/components/UserAccount/AccountFavorite.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
 import styles from "../../styles/UserAccount/AccountFavorite.module.css";
 
 interface Article {
@@ -36,7 +37,9 @@ export default function FavoriteAccount() {
                 .filter((article) => favoriteIds.includes(article.id))
                 .map((article) => (
                   <section key={article.id} className={styles.favoriteArticles}>
-                    <li className={styles.name}>{article.name}</li>
+                    <NavLink to={`/shop/article/${article.id}`}>
+                      <li className={styles.name}>{article.name}</li>
+                    </NavLink>
                     {article.stock > 0 ? (
                       <p className={styles.stock}>
                         <span


### PR DESCRIPTION
- Quand l'utilisateur n'est pas connecté, le lien "favoris" n'apparait pas dans le header.
- Quand il n'est pas connecté et qu'il essaie d'ajouter un favoris, une alerte lui signale qu'il doit se connecter pour ajouter.
- Lorsqu'il est connecté et dans ses favoris, il peut cliquer sur le nom du favoris pour aller sur la page de l'article